### PR TITLE
Updates to NSPropertyDescription

### DIFF
--- a/Groot/Private/NSPropertyDescription+Groot.m
+++ b/Groot/Private/NSPropertyDescription+Groot.m
@@ -25,7 +25,12 @@
 @implementation NSPropertyDescription (Groot)
 
 - (nullable NSString *)grt_JSONKeyPath {
-    return self.userInfo[@"JSONKeyPath"];
+    
+    if (self.userInfo[@"JSONKeyPath"]) {
+        return self.userInfo[@"JSONKeyPath"];
+    }
+    
+    return [self name];
 }
 
 - (BOOL)grt_JSONSerializable {
@@ -36,7 +41,27 @@
     NSString *keyPath = [self grt_JSONKeyPath];
     
     if (keyPath != nil) {
-        return [dictionary valueForKeyPath:keyPath];
+        //Try to split key path with '.'
+        NSArray *splitKeyPathWithDot = [keyPath componentsSeparatedByString:@"."];
+        //If only one item then that is our key
+        if ([splitKeyPathWithDot count] == 1) {
+            return [dictionary valueForKeyPath:keyPath];
+        } else {
+            //We have item similar to "links.users"
+            id object;
+            NSDictionary *tempDict;
+            //Iterate through each key in array
+            for (NSString *key in splitKeyPathWithDot) {
+                //if dictionary exists lets keep for next iteration
+                if ([dictionary[key] isKindOfClass:[NSDictionary class]]) {
+                    tempDict = dictionary[key];
+                }
+                //Try to get the object if it exists
+                object = tempDict ? tempDict[key] : nil;                
+            }            
+            return object;
+        }
+        
     }
     
     return nil;


### PR DESCRIPTION
Xcode is a mess when editing userinfo in Data Model. I rather add userinfo only when it is needed than add for all properties. So it was easier to match the property names to our API response and add JSONKeyPath for those that didn't match. So the end results was that only `id` key needed to be updated on all models and some relationship keys.

Our API follows JSON-API standards so JSON can include `links.users : [array_of_ids]`. It meant I had to normalize the data after the response was received which was just a problem of big O. So instead I have added provisions in the code to allow JSONKeyPath to be a path to the object. So in our case `users` relationship has JSONKeyPath of `links.users` which means no more normalizing the data!